### PR TITLE
fix: address review regressions in scheduler

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,22 +46,21 @@ fn show_card_window_internal(app: &tauri::AppHandle) {
             let screen_size = monitor.size();
             let window_width = 480;
             let window_height = 460;
-            let margin = 1000;
-            let margin_bottom = 1000;
+            let margin_x = 24;
+            let margin_y = 24;
             let offset = 20;
 
             // 定义安全区域边界
-            let safe_left = margin;
-            let safe_right = (screen_size.width as i32) - margin;
-            let safe_top = margin;
-            let safe_bottom = (screen_size.height as i32) - margin_bottom;
+            let safe_left = margin_x;
+            let safe_right = (screen_size.width as i32) - margin_x;
+            let safe_top = margin_y;
+            let safe_bottom = (screen_size.height as i32) - margin_y;
 
             // 获取鼠标位置
-            let (mouse_x, mouse_y) = window.cursor_position()
+            let (mouse_x, mouse_y) = window
+                .cursor_position()
                 .map(|pos| (pos.x as i32, pos.y as i32))
-                .unwrap_or_else(|_| {
-                    (screen_size.width as i32 / 2, screen_size.height as i32 / 2)
-                });
+                .unwrap_or_else(|_| (screen_size.width as i32 / 2, screen_size.height as i32 / 2));
 
             // 尝试放在鼠标右下方
             let mut x = mouse_x + offset;
@@ -78,10 +77,13 @@ fn show_card_window_internal(app: &tauri::AppHandle) {
             }
 
             // 确保窗口完全在安全区域内
-            x = x.max(safe_left).min(safe_right - window_width);
-            y = y.max(safe_top).min(safe_bottom - window_height);
+            let max_x = (safe_right - window_width).max(safe_left);
+            let max_y = (safe_bottom - window_height).max(safe_top);
+            x = x.max(safe_left).min(max_x);
+            y = y.max(safe_top).min(max_y);
 
-            let _ = window.set_position(tauri::Position::Physical(tauri::PhysicalPosition { x, y }));
+            let _ =
+                window.set_position(tauri::Position::Physical(tauri::PhysicalPosition { x, y }));
         }
 
         let _ = window.set_always_on_top(true);

--- a/src/domain/scheduler/triggerScheduler.test.ts
+++ b/src/domain/scheduler/triggerScheduler.test.ts
@@ -190,7 +190,7 @@ describe('TriggerScheduler', () => {
 
   describe('main window activity', () => {
     it('主页面处于活动状态时不触发浮卡', async () => {
-      visibilityState = 'visible';
+      vi.spyOn(document, 'hasFocus').mockReturnValue(true);
       vi.mocked(invoke).mockResolvedValue(100);
 
       const shouldTrigger = await (scheduler as any).shouldTriggerCard();

--- a/src/main.ts
+++ b/src/main.ts
@@ -130,6 +130,7 @@ let currentExportBundle: ExportBundle | null = null;
 let schedulerStarted = false;
 let saveHintTimer: number | null = null;
 let lastErrorMessage: string | null = null;
+let schedulerUnlistenFns: Array<() => void> = [];
 
 const WORDBOOK_PREVIEW_PAGE_SIZE = 12;
 
@@ -973,18 +974,16 @@ async function refreshDashboard() {
   renderConsole();
 }
 
-async function saveConfig() {
+async function saveConfig(): Promise<boolean> {
   try {
     const previousConfig = cloneConfig(currentConfig);
     const nextConfig = readConfigFromForm();
-    console.log('💾 saveConfig - nextConfig.reminder:', nextConfig.reminder);
 
     const requestedLaunchAtLogin = nextConfig.system.launch_at_login;
     const launchAtLogin = await syncLaunchAtLogin(requestedLaunchAtLogin);
     nextConfig.system.launch_at_login = launchAtLogin;
 
     currentConfig = await invoke<AppConfig>('update_app_config', { config: nextConfig });
-    console.log('✅ saveConfig - backend returned:', currentConfig.reminder);
 
     currentExportBundle = null;
     triggerScheduler.updateConfig(currentConfig);
@@ -997,7 +996,7 @@ async function saveConfig() {
 
     if (launchAtLogin !== requestedLaunchAtLogin) {
       setSaveHint('设置已保存，但开机启动未能按预期更新。');
-      return;
+      return true;
     }
 
     setSaveHint(
@@ -1005,10 +1004,12 @@ async function saveConfig() {
         ? '设置已保存。启动行为和托盘开关会在下次启动时完全生效。'
         : '设置已保存，调度器会按新配置继续运行。',
     );
+    return true;
   } catch (error) {
     lastErrorMessage = getErrorMessage(error);
     renderConsole();
     setSaveHint('保存失败，请检查当前配置后重试。');
+    return false;
   }
 }
 
@@ -1097,15 +1098,11 @@ async function resumeScheduler() {
   }
 }
 
-function initScheduler() {
-  console.log('🚀 initScheduler called, schedulerStarted:', schedulerStarted);
-
+async function initScheduler() {
   if (schedulerStarted) {
-    console.log('⚠️  Scheduler already started, skipping');
     return;
   }
 
-  // 不再在这里更新配置，由调用方负责
   triggerScheduler.syncPauseUntil(currentDashboard?.pause_until);
   triggerScheduler.start(async () => {
     await invoke('show_card_window');
@@ -1113,21 +1110,28 @@ function initScheduler() {
     renderConsole();
   });
 
-  void listen('card-window-hidden', async () => {
+  schedulerUnlistenFns.push(await listen('card-window-hidden', async () => {
     triggerScheduler.markCardHidden();
     await refreshDashboard();
-  });
+  }));
 
-  void listen('scheduler-paused', async (event) => {
+  schedulerUnlistenFns.push(await listen('scheduler-paused', async (event) => {
     const minutes = Number(event.payload);
     if (!Number.isNaN(minutes) && minutes > 0) {
       triggerScheduler.pause(minutes);
       await refreshDashboard();
     }
-  });
+  }));
 
   schedulerStarted = true;
-  console.log('✅ Scheduler initialized and started');
+}
+
+function stopScheduler() {
+  triggerScheduler.stop();
+  schedulerStarted = false;
+  schedulerUnlistenFns.splice(0).forEach((unlisten) => {
+    unlisten();
+  });
 }
 
 function wireControls() {
@@ -1197,33 +1201,23 @@ function wireControls() {
     void resumeScheduler();
   });
   startSchedulerBtn.addEventListener('click', async () => {
-    console.log('🔵 开始提醒按钮被点击');
-
-    // 先读取表单配置
-    const newConfig = readConfigFromForm();
-    console.log('📝 读取的新配置:', newConfig.reminder);
-
-    // 尝试保存配置
-    await saveConfig();
-
-    // 如果调度器已经启动，先停止再重新启动
-    if (schedulerStarted) {
-      triggerScheduler.stop();
-      schedulerStarted = false;
+    const saved = await saveConfig();
+    if (!saved) {
+      return;
     }
 
-    // 使用新配置更新调度器（不依赖currentConfig）
-    triggerScheduler.updateConfig(newConfig);
-    console.log('🔄 调度器配置已更新为:', newConfig.reminder);
+    if (schedulerStarted) {
+      stopScheduler();
+    }
 
-    initScheduler();
+    triggerScheduler.updateConfig(currentConfig);
+    await initScheduler();
     startSchedulerBtn.style.display = 'none';
     stopSchedulerBtn.style.display = 'inline-block';
     renderConsole();
   });
   stopSchedulerBtn.addEventListener('click', () => {
-    triggerScheduler.stop();
-    schedulerStarted = false;
+    stopScheduler();
     startSchedulerBtn.style.display = 'inline-block';
     stopSchedulerBtn.style.display = 'none';
     renderConsole();


### PR DESCRIPTION
## Summary

Fix two review regressions introduced after the passive-reminder refactor:

- keep the flashcard window on-screen across common monitor sizes
- prevent scheduler event listeners and unsanitized config from leaking across repeated start/stop cycles

## What changed

- replace the `1000px` fixed flashcard margins with bounded screen-edge margins in `src-tauri/src/lib.rs`
- clamp the card window position using a computed max bound so smaller screens do not produce negative coordinates
- make `saveConfig()` return success/failure instead of silently swallowing errors
- start the scheduler only after config persistence succeeds
- use normalized `currentConfig` when starting reminders instead of the pre-save form snapshot
- add `stopScheduler()` cleanup so repeated start/stop does not accumulate `listen(...)` handlers
- update the scheduler test to assert main-window activity through `document.hasFocus()` rather than stale `visibilityState`

## Validation

- `npm ci`
- `npm run build`
- `npm test`
- `cargo test`
- `npm run tauri build -- --bundles app`

## Notes

- `npm ci` was needed locally because `tsc` and `vitest` were missing from PATH before reinstalling dependencies
